### PR TITLE
Tweak setdiff to preserve table1 column types

### DIFF
--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -479,8 +479,6 @@ class TestSetdiff():
     def test_default_same_columns(self, operation_table_type):
         self._setup(operation_table_type)
         out = table.setdiff(self.t1, self.t2)
-        self.t1 = operation_table_type(self.t1, masked=True)
-        self.t2 = operation_table_type(self.t2, masked=True)
         assert type(out['a']) is type(self.t1['a'])
         assert type(out['b']) is type(self.t1['b'])
         assert out.pformat() == [' a   b ',
@@ -506,8 +504,6 @@ class TestSetdiff():
     def test_extra_col_right_table(self, operation_table_type):
         self._setup(operation_table_type)
         out = table.setdiff(self.t1, self.t3)
-        self.t1 = operation_table_type(self.t1, masked=True)
-        self.t3 = operation_table_type(self.t3, masked=True)
 
         assert type(out['a']) is type(self.t1['a'])
         assert type(out['b']) is type(self.t1['b'])
@@ -519,8 +515,6 @@ class TestSetdiff():
     def test_keys(self, operation_table_type):
         self._setup(operation_table_type)
         out = table.setdiff(self.t3, self.t1, keys=['a', 'b'])
-        self.t1 = operation_table_type(self.t1, masked=True)
-        self.t3 = operation_table_type(self.t3, masked=True)
 
         assert type(out['a']) is type(self.t1['a'])
         assert type(out['b']) is type(self.t1['b'])


### PR DESCRIPTION
@SaraOgaz - your tests showed a problem in the original implementation idea I proposed (good tests!!), namely that the output columns are always masked even if the originals are not.  That forced you into lines like `self.t1 = operation_table_type(self.t1, masked=True)`.  This is not the desired behavior, so I went ahead and fixed that up in this PR to your branch.

The changes look bigger than they really are because I had to also make a light copy of `table1` but in this case the original `table1` was also needed in the end.  So this forced a naming change.

I *think* that with this change it will be good for merge to astropy master.  :smile: